### PR TITLE
Issue 35

### DIFF
--- a/haascli/__init__.py
+++ b/haascli/__init__.py
@@ -1,8 +1,6 @@
 import os
 import logging
 
-import coloredlogs
-
 
 __version__ = '0.0.1'
 
@@ -18,7 +16,6 @@ console_fmt = '%(name)s:%(levelname)s:%(message)s'
 console_formatter = logging.Formatter(console_fmt)
 console_handler.setFormatter(console_formatter)
 logger.addHandler(console_handler)
-coloredlogs.install(level=logging.ERROR, logger=logger)
 
 
 def bad_response(response):
@@ -33,16 +30,16 @@ def bad_response(response):
 def setup_logging(level=logging.INFO, file=DEFAULT_LOG):
     '''create file hamdler'''
     logger.setLevel(level)
+
     if file == '-':
         console_handler.setLevel(level)
-        coloredlogs.install(level=level, logger=logger)
     else:
-        if file:
-            file_handler = logging.FileHandler(file)
-        else:
+        if file is None:
             file_handler = logging.FileHandler(DEFAULT_LOG)
-        file_handler.setLevel(level)
+        elif file:
+            file_handler = logging.FileHandler(file)
         file_fmt = '%(asctime)s:%(name)s:%(levelname)s:%(message)s'
         file_formatter = logging.Formatter(file_fmt)
+        file_handler.setLevel(level)
         file_handler.setFormatter(file_formatter)
         logger.addHandler(file_handler)

--- a/haascli/stack.py
+++ b/haascli/stack.py
@@ -27,14 +27,15 @@ def cli(ctx, **kwargs):
     if ctx.obj['secret']:
         optargs['aws_secret_access_key_id'] = ctx.obj['secret']
     logger.debug('aws settings:\n{}'.format(
-                 '\n'.join(['{}={}'.format(k, v) for k, v in optargs.items()])))
+                 '\n'.join(
+                     ['{}={}'.format(k, v) for k, v in optargs.items()])))
 
     # open the client here instead of in all commands
     if ctx.obj['exec']:
         try:
             ctx.obj['client'] = boto3.client('cloudformation', **optargs)
         except (ClientError, PartialCredentialsError) as e:
-            logger.error(str(e))
+            logger.error('AWS Credentials: ' + str(e))
             ctx.abort()
 
 
@@ -59,7 +60,9 @@ def create(ctx, stack_name, config_file, parameter, wait):
             # @TODO: assuming all config files are yaml
             parameters = yaml.load(f)
         except IOError as e:
-            logger.error(str(e))
+            print(click.style(
+                'ERROR: Could not open config file: {}', fg='red')
+                .format(str(e)))
             ctx.abort()
     else:
         for param in parameter:
@@ -77,7 +80,7 @@ def create(ctx, stack_name, config_file, parameter, wait):
         template_url = parameters['template_url']
         del parameters['template_url']
     except KeyError as e:
-        logger.error('must define template_url')
+        print(click.style('ERROR: Must define template_url', fg='red'))
         ctx.abort()
 
     if ctx.obj['debug']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ certifi==2017.7.27.1
 chardet==3.0.4
 click==6.7
 colorama==0.3.7
-coloredlogs==7.1
 decorator==4.1.2
 docutils==0.13.1
 executor==18.0

--- a/tests/test_stack_create.py
+++ b/tests/test_stack_create.py
@@ -5,6 +5,7 @@ from haascli.haas import cli
 from click.testing import CliRunner
 from moto import mock_cloudformation
 from haascli import ROOT_DIR
+from haascli import logger, console_handler
 
 
 GITHUB_CFT_URL = 'https://raw.githubusercontent.com/vin0110/haas/master/'\
@@ -26,6 +27,9 @@ class TestStackCreate(unittest.TestCase):
         f = open(os.path.join(self.template_file), 'r')
         self.template_body = f.read()
         f.close()
+
+        # disable error logging during testing
+        logger.removeHandler(console_handler)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Removed coloredlogs. It is not what we want. First, it is an additional requirement that needs special handling on windows. More importantly it wasn't designed for what we want--extreme overkill. For example, coloredlogs makes extensive use of env vars so the user can customize the error message format. But it does not (easily) allow the developer to customize the format.

Additionally, sending some error messages to stdout directly (such as missing arguments) because they needn't be logged.

Last, disabled the logger in test program.